### PR TITLE
Fix map changing while using stairs

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -2003,6 +2003,9 @@ void UseStairs(WINDOW *wCamera, WINDOW *wAlert, TILE_TYPE sTileIndex[], cPlayer 
 			{
 				nCameraY = Player->nTargetStairList[i].nDestinationY;
 				nCameraX = Player->nTargetStairList[i].nDestinationX;
+				Player->nTargetY = Player->nTargetStairList[i].nDestinationY;
+				Player->nTargetX = Player->nTargetStairList[i].nDestinationX;
+				
 				Player->bInCave = Player->nTargetStairList[i].bInCave;
 				if( Player->nTargetMap != Player->nTargetStairList[i].nDestinationMap )
 				{


### PR DESCRIPTION
Fixed a bug that was causing the incorrect location to be used when
changing maps while using stairs